### PR TITLE
Fix: Bump log4j-core to 2.25.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.24.0</version>
+            <version>2.25.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This PR fixes the Log4j vulnerability by upgrading the log4j-core dependency to version 2.25.0.